### PR TITLE
Add diagram for one-ai-mini-project

### DIFF
--- a/system-design/database.md
+++ b/system-design/database.md
@@ -1,0 +1,65 @@
+```mermaid
+
+erDiagram
+    NEWS {
+        int id PK
+        varchar title
+        varchar slug UK
+        text content
+        timestamp published_at
+        varchar thumbnail_url
+        boolean is_featured
+        int category_id FK
+        timestamp created_at
+        timestamp updated_at
+    }
+    
+    CATEGORIES {
+        int id PK
+        varchar name UK
+        varchar slug UK
+    }
+    
+    TAGS {
+        int id PK
+        varchar name UK
+        varchar slug UK
+    }
+    
+    NEWS_TAGS {
+        int id PK
+        int news_id FK
+        int tag_id FK
+    }
+    
+    NEWS_METRICS {
+        int id PK
+        int news_id FK,UK
+        int view_count
+        timestamp last_updated
+    }
+    
+    ENTITIES {
+        int id PK
+        varchar name
+        varchar entity_type
+        jsonb metadata
+    }
+    
+    NEWS_ENTITIES {
+        int id PK
+        int news_id FK
+        int entity_id FK
+        varchar role
+    }
+    
+    NEWS ||--o{ NEWS_TAGS : "has"
+    TAGS ||--o{ NEWS_TAGS : "belongs_to"
+    
+    NEWS ||--|| NEWS_METRICS : "has"
+    
+    CATEGORIES ||--o{ NEWS : "contains"
+    
+    NEWS ||--o{ NEWS_ENTITIES : "has"
+    ENTITIES ||--o{ NEWS_ENTITIES : "belongs_to"
+```


### PR DESCRIPTION
## Summary

This pull request adds the initial ER diagram for the NBA news system using Mermaid syntax. The design outlines the key entities and their relationships within the system, including news articles, categories, tags, metrics, and named entities.

## Features

- `NEWS`, `CATEGORIES`, and `TAGS` core entities.
- Support for many-to-many relationships via `NEWS_TAGS` and `NEWS_ENTITIES`.
- Inclusion of `NEWS_METRICS` to track view counts and update times.
- Use of `jsonb` metadata for flexible entity information.

## Notes

- Mermaid syntax is used to visualize the ER diagram directly in Markdown-compatible tools.
- Slugs are uniquely constrained to support SEO-friendly URLs.
- This serves as the foundation for further schema development and API integration.